### PR TITLE
correctly deal with templates in directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = '1.3.0'
+VERSION = '1.3.1'
 
 
 setup(


### PR DESCRIPTION
Had a situation where I had a subdirectory with templates in that wasn't being correctly handled. This PR corrects that behaviour.

Things work as expected thanks to `jinja2` itself. I.e. subdirectories in the src are reflected in the compiled html.