### PR TITLE
Check if target file is not also a source file before writing

### DIFF
--- a/jinja2_standalone_compiler/__init__.py
+++ b/jinja2_standalone_compiler/__init__.py
@@ -128,6 +128,8 @@ def main(path, out_path=None, verbose=False, silent=False, settings=None):
 
         print_log('  Creating: ' + style_RENDERED_FILE + template_file, False, verbose, silent)
 
+        if os.path.abspath(jinja_template) == os.path.abspath(template_file):
+            raise IOError("write target is also a source file, aborting to prevent blanking")
         try:
             with open(template_file, 'w') as f:
                 f.write(render_template(


### PR DESCRIPTION
And abort if it is, because that would overwrite a source file, which is bad.

If the extension is .html and you don't specify --out, it will blank the file (it happened to me).